### PR TITLE
Support for Base64 attachments

### DIFF
--- a/client/basic/client.ts
+++ b/client/basic/client.ts
@@ -260,11 +260,10 @@ export class SMTPClient {
 
         await this.#connection.writeCmd(
           "Content-Disposition: attachment; filename=" + attachment.filename,
-          "\r\n",
         );
 
         if (attachment.encoding === "binary") {
-          await this.#connection.writeCmd("Content-Transfer-Encoding: binary");
+          await this.#connection.writeCmd("Content-Transfer-Encoding: binary\r\n");
 
           if (
             attachment.content instanceof ArrayBuffer ||

--- a/config/mail/attachments.ts
+++ b/config/mail/attachments.ts
@@ -1,5 +1,3 @@
-import { base64Decode } from "./encoding.ts";
-
 interface baseAttachment {
   contentType: string;
   filename: string;
@@ -17,6 +15,7 @@ export type ResolvedAttachment =
   & (
     | textAttachment
     | arrayBufferLikeAttachment
+    | base64Attachment
   )
   & baseAttachment;
 
@@ -28,14 +27,5 @@ type arrayBufferLikeAttachment = {
 };
 
 export function resolveAttachment(attachment: Attachment): ResolvedAttachment {
-  if (attachment.encoding === "base64") {
-    return {
-      filename: attachment.filename,
-      contentType: attachment.contentType,
-      encoding: "binary",
-      content: base64Decode(attachment.content),
-    };
-  } else {
     return attachment;
-  }
 }


### PR DESCRIPTION
- Removed code forcing conversion of base64 into binary
- Allowed sending base64 attachments
- Corrected new lines in the wrong places

Fixes #25 

Notes: No matter what I tried, I was never able to make the binary attachments work. So instead I added support for sending Base64 attachments. That works with GMail and Hotmail.

The core issue with binary attachments is that the Deno.Writer.write method (or something deeper in Rust) seems to be correction the binary "LF" and "CR" to "CRLF" always. I could not see any way to stop that from happening, so I gave up.

Let me know what you think of the code changes.