### PR TITLE
Added auto generated Content ID header support

### DIFF
--- a/client/basic/client.ts
+++ b/client/basic/client.ts
@@ -259,6 +259,10 @@ export class SMTPClient {
         );
 
         await this.#connection.writeCmd(
+          `Content-ID: <attachment_id_${i}>`,
+        );
+
+        await this.#connection.writeCmd(
           "Content-Disposition: attachment; filename=" + attachment.filename,
           "\r\n",
         );


### PR DESCRIPTION
- Added support for auto generated Content ID headers per attachment

Usage:

```ts
await client.send({
  // Other items...
  html:
  'First image attachment <img src="cid:attachment_id_0"/> Second image attachment <img src="cid:attachment_id_1"/>',
});
```

In support of #25 