### PR TITLE
fix: base64 attachment whitespace

### DIFF
--- a/client/basic/client.ts
+++ b/client/basic/client.ts
@@ -244,8 +244,7 @@ export class SMTPClient {
 
         if (attachment.encoding === "base64") {
           this.#connection.writeCmd(
-            "Content-Transfer-Encoding: base64",
-            "\r\n",
+            "Content-Transfer-Encoding: base64\r\n",
           );
 
           for (


### PR DESCRIPTION
Hello. When using a base64 attachment writeCmd adds a single space between 'Content-Transfer-Encoding: base64' and the newline. Most email clients simply ignore it, however, at least Apple Mail does not and consequently fails to decode the attachment.