### PR TITLE
feat/encoders & feat/related-attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ export interface SendConfig {
   content?: string;
   mimeContent?: Content[];
   html?: string;
+  relatedAttachments?: Attachment[];
   inReplyTo?: string;
   replyTo?: string;
   references?: string;
@@ -301,6 +302,10 @@ You can encode an array of attachments as base64, text, or binary. Note that
 base64 is converted to binary and is only present for a better API. So don't
 encode your binary files as base64, otherwise denomailer can't convert it back
 to binary.
+
+#### relatedAttachments
+
+Attachments related to the html content, for example embedded images.
 
 #### internalTag
 

--- a/client/basic/client.ts
+++ b/client/basic/client.ts
@@ -85,22 +85,22 @@ export class SMTPClient {
     this.#connection.writeCmd(
       `Content-Type: ${attachment.contentType}; name=${attachment.filename}`,
     );
-  
+
     if (attachment.contentID) {
       this.#connection.writeCmd(
         `Content-ID: <${attachment.contentID}>`,
       );
     }
-  
+
     this.#connection.writeCmd(
       `Content-Disposition: ${attachment.contentDisposition}; filename=${attachment.filename}`,
     );
-  
+
     if (attachment.encoding === "base64") {
       this.#connection.writeCmd(
         "Content-Transfer-Encoding: base64\r\n",
       );
-  
+
       for (
         let line = 0;
         line < Math.ceil(attachment.content.length / 75);
@@ -110,16 +110,16 @@ export class SMTPClient {
           line * 75,
           (line + 1) * 75,
         );
-  
+
         this.#connection.writeCmd(lineOfBase64);
       }
-  
+
       this.#connection.writeCmd("\r\n");
     } else if (attachment.encoding === "text") {
       this.#connection.writeCmd(
         "Content-Transfer-Encoding: quoted-printable\r\n",
       );
-  
+
       this.#connection.writeCmd(attachment.content + "\r\n");
     }
   }

--- a/client/basic/client.ts
+++ b/client/basic/client.ts
@@ -1,4 +1,6 @@
 import type { ResolvedSendConfig } from "../../config/mail/mod.ts";
+import type { ResolvedContent } from "../../config/mail/content.ts";
+import type { ResolvedAttachment } from "../../config/mail/attachments.ts";
 import { ResolvedClientOptions } from "../../config/client.ts";
 import { SMTPConnection } from "./connection.ts";
 import { QUE } from "./QUE.ts";
@@ -51,6 +53,75 @@ export class SMTPClient {
 
   get idle() {
     return this.#que.idle;
+  }
+
+  calcBoundary(content: string, pattern: RegExp): number {
+    let boundary = 100;
+
+    const matches = content.matchAll(pattern);
+    for (const match of matches) {
+      boundary += parseInt(match[1], 10);
+    }
+
+    return boundary;
+  }
+
+  encodeContent(content: ResolvedContent) {
+    this.#connection.writeCmd(
+      "Content-Type: " + content.mimeType,
+    );
+    if (content.transferEncoding) {
+      this.#connection.writeCmd(
+        `Content-Transfer-Encoding: ${content.transferEncoding}\r\n`,
+      );
+    } else {
+      this.#connection.writeCmd("");
+    }
+
+    this.#connection.writeCmd(content.content + "\r\n");
+  }
+
+  encodeAttachment(attachment: ResolvedAttachment) {
+    this.#connection.writeCmd(
+      `Content-Type: ${attachment.contentType}; name=${attachment.filename}`,
+    );
+  
+    if (attachment.contentID) {
+      this.#connection.writeCmd(
+        `Content-ID: <${attachment.contentID}>`,
+      );
+    }
+  
+    this.#connection.writeCmd(
+      `Content-Disposition: ${attachment.contentDisposition}; filename=${attachment.filename}`,
+    );
+  
+    if (attachment.encoding === "base64") {
+      this.#connection.writeCmd(
+        "Content-Transfer-Encoding: base64\r\n",
+      );
+  
+      for (
+        let line = 0;
+        line < Math.ceil(attachment.content.length / 75);
+        line++
+      ) {
+        const lineOfBase64 = attachment.content.slice(
+          line * 75,
+          (line + 1) * 75,
+        );
+  
+        this.#connection.writeCmd(lineOfBase64);
+      }
+  
+      this.#connection.writeCmd("\r\n");
+    } else if (attachment.encoding === "text") {
+      this.#connection.writeCmd(
+        "Content-Transfer-Encoding: quoted-printable\r\n",
+      );
+  
+      this.#connection.writeCmd(attachment.content + "\r\n");
+    }
   }
 
   async send(config: ResolvedSendConfig) {
@@ -144,34 +215,10 @@ export class SMTPClient {
 
       this.#connection.writeCmd("MIME-Version: 1.0");
 
-      let boundaryAdditionAtt = 100;
-      // calc msg boundary
-      // TODO: replace this with a match or so.
-      config.mimeContent.map((v) => v.content).join("\n").replace(
+      const boundaryAdditionAtt = this.calcBoundary(
+        config.mimeContent.map((v) => v.content).join("\n") + "\n" +
+          config.attachments.map((v) => v.content).join("\n"),
         new RegExp("--attachment([0-9]+)", "g"),
-        (_, numb) => {
-          boundaryAdditionAtt += parseInt(numb, 10);
-
-          return "";
-        },
-      );
-
-      // const dec = new TextDecoder();
-
-      config.attachments.map((v) => {
-        return v.content;
-        // if (v.encoding === "text") return v.content;
-
-        // const arr = new Uint8Array(v.content);
-
-        // return dec.decode(arr);
-      }).join("\n").replace(
-        new RegExp("--attachment([0-9]+)", "g"),
-        (_, numb) => {
-          boundaryAdditionAtt += parseInt(numb, 10);
-
-          return "";
-        },
       );
 
       const attachmentBoundary = `attachment${boundaryAdditionAtt}`;
@@ -182,19 +229,12 @@ export class SMTPClient {
       );
       this.#connection.writeCmd(`--${attachmentBoundary}`);
 
-      let boundaryAddition = 100;
-      // calc msg boundary
-      // TODO: replace this with a match or so.
-      config.mimeContent.map((v) => v.content).join("\n").replace(
+      const boundaryAdditionMsg = this.calcBoundary(
+        config.mimeContent.map((v) => v.content).join("\n"),
         new RegExp("--message([0-9]+)", "g"),
-        (_, numb) => {
-          boundaryAddition += parseInt(numb, 10);
-
-          return "";
-        },
       );
 
-      const messageBoundary = `message${boundaryAddition}`;
+      const messageBoundary = `message${boundaryAdditionMsg}`;
 
       this.#connection.writeCmd(
         `Content-Type: multipart/alternative; boundary=${messageBoundary}`,
@@ -203,83 +243,18 @@ export class SMTPClient {
 
       for (let i = 0; i < config.mimeContent.length; i++) {
         this.#connection.writeCmd(`--${messageBoundary}`);
-        this.#connection.writeCmd(
-          "Content-Type: " + config.mimeContent[i].mimeType,
-        );
-        if (config.mimeContent[i].transferEncoding) {
-          this.#connection.writeCmd(
-            `Content-Transfer-Encoding: ${
-              config.mimeContent[i].transferEncoding
-            }` + "\r\n",
-          );
+        if (config.mimeContent[i].relatedAttachments.length === 0) {
+          this.encodeContent(config.mimeContent[i]);
         } else {
-          // Send new line
-          this.#connection.writeCmd("");
+          this.encodeRelated(config.mimeContent[i]);
         }
-
-        this.#connection.writeCmd(config.mimeContent[i].content, "\r\n");
       }
 
       this.#connection.writeCmd(`--${messageBoundary}--\r\n`);
 
       for (let i = 0; i < config.attachments.length; i++) {
-        const attachment = config.attachments[i];
-
         this.#connection.writeCmd(`--${attachmentBoundary}`);
-        this.#connection.writeCmd(
-          "Content-Type:",
-          attachment.contentType + ";",
-          "name=" + attachment.filename,
-        );
-
-        if (attachment.contentID) {
-          this.#connection.writeCmd(
-            `Content-ID: <${attachment.contentID}>`,
-          );
-        }
-
-        this.#connection.writeCmd(
-          "Content-Disposition: attachment; filename=" + attachment.filename,
-        );
-
-        if (attachment.encoding === "base64") {
-          this.#connection.writeCmd(
-            "Content-Transfer-Encoding: base64\r\n",
-          );
-
-          for (
-            let line = 0;
-            line < Math.ceil(attachment.content.length / 75);
-            line++
-          ) {
-            const lineOfBase64 = attachment.content.slice(
-              line * 75,
-              (line + 1) * 75,
-            );
-
-            this.#connection.writeCmd(lineOfBase64);
-          }
-
-          // if (
-          //   attachment.content instanceof ArrayBuffer ||
-          //   attachment.content instanceof SharedArrayBuffer
-          // ) {
-          //   await this.#connection.writeCmdBinary(
-          //     new Uint8Array(attachment.content),
-          //   );
-          // } else {
-          //   await this.#connection.writeCmdBinary(attachment.content);
-          // }
-
-          this.#connection.writeCmd("\r\n");
-        } else if (attachment.encoding === "text") {
-          this.#connection.writeCmd(
-            "Content-Transfer-Encoding: quoted-printable",
-            "\r\n",
-          );
-
-          this.#connection.writeCmd(attachment.content, "\r\n");
-        }
+        this.encodeAttachment(config.attachments[i]);
       }
 
       this.#connection.writeCmd(`--${attachmentBoundary}--\r\n`);

--- a/config/mail/attachments.ts
+++ b/config/mail/attachments.ts
@@ -12,14 +12,16 @@ export type Attachment =
     | base64Attachment
     | arrayBufferLikeAttachment
   )
-  & baseAttachment;
+  & baseAttachment
+  & { contentDisposition?: "attachment" | "inline" };
 
 export type ResolvedAttachment =
   & (
     | textAttachment
     | base64Attachment
   )
-  & baseAttachment;
+  & baseAttachment
+  & { contentDisposition: "attachment" | "inline" };
 
 type textAttachment = { encoding: "text"; content: string };
 type base64Attachment = { encoding: "base64"; content: string };
@@ -35,8 +37,15 @@ export function resolveAttachment(attachment: Attachment): ResolvedAttachment {
       contentType: attachment.contentType,
       encoding: "base64",
       content: base64Encode(attachment.content),
+      contentDisposition: attachment.contentDisposition ?? "attachment",
     };
   } else {
-    return attachment;
+    return {
+      filename: attachment.filename,
+      contentType: attachment.contentType,
+      encoding: attachment.encoding,
+      content: attachment.content,
+      contentDisposition: attachment.contentDisposition ?? "attachment",
+    };
   }
 }

--- a/config/mail/mod.ts
+++ b/config/mail/mod.ts
@@ -3,7 +3,7 @@ import {
   resolveAttachment,
   ResolvedAttachment,
 } from "./attachments.ts";
-import { Content, resolveContent } from "./content.ts";
+import { Content, ResolvedContent, resolveMessage } from "./content.ts";
 import {
   isSingleMail,
   mailList,
@@ -28,6 +28,7 @@ export interface SendConfig {
   content?: string;
   mimeContent?: Content[];
   html?: string;
+  relatedAttachments?: Attachment[];
   inReplyTo?: string;
   replyTo?: string;
   references?: string;
@@ -48,7 +49,7 @@ export interface ResolvedSendConfig {
   from: saveMailObject;
   date: string;
   subject: string;
-  mimeContent: Content[];
+  mimeContent: ResolvedContent[];
   inReplyTo?: string;
   replyTo?: saveMailObject;
   references?: string;
@@ -69,6 +70,7 @@ export function resolveSendConfig(config: SendConfig): ResolvedSendConfig {
     content,
     mimeContent,
     html,
+    relatedAttachments,
     inReplyTo,
     replyTo,
     references,
@@ -84,9 +86,10 @@ export function resolveSendConfig(config: SendConfig): ResolvedSendConfig {
     bcc: parseMailList(bcc),
     from: parseSingleEmail(from),
     date,
-    mimeContent: resolveContent({
+    mimeContent: resolveMessage({
       mimeContent,
       html,
+      relatedAttachments,
       text: content,
     }),
     replyTo: replyTo ? parseSingleEmail(replyTo) : undefined,


### PR DESCRIPTION
Hello. I feel I need to prefix this PR with a little justification: This PR has multiple parts to it and most of them should have been discussed in an Issue beforehand. But, since we needed these features fast I sadly did not have the time to do so before beginning development. I hope it can still be useful and understand that it may need reworking.

The **goal** of this PR was to allow users to **embed images**. This necessitated or at least encouraged multiple other changes.

### feat/related-attachments
Implements `Content-Type: multiple/related` for mimeContent.
To quote [Wikipedia](https://en.wikipedia.org/wiki/MIME#related):
> One common usage of this subtype is to send a web page complete with images in a single message. The root part would contain the [HTML](https://en.wikipedia.org/wiki/HTML) document, and use image tags to reference images stored in the latter parts.

#### Minimal Example
 ```ts
await client.send({
	html: '<p><b>Follow us on</b></p><p><a href=""><img src="cid:logo"></a></p>',
	relatedAttachments: [
		{
			content: logoB64,
			filename: "logo",
			encoding: "base64",
			contentType: "image/png",
			contentID: "logo",
			contentDisposition: "inline",
		}
	],
});
```
Result:
![logo](https://user-images.githubusercontent.com/83299891/214984630-907d8129-ca7a-46ef-a5e7-77f171b1aaf8.png)

#### Implementation
Added an optional field `relatedAttachments` on `Content`. Also added an optional field `relatedAttachments` on `SendConfig` that populates the `relatedAttachments` field of the html mime entry upon being resolved.

Then in `SMTPClient.send` check if there are relatedAttachments and if so use the `encodeRelated` encoder to first encode the mimeContent itself and then the attachments inside a `Content-Type: multipart/related` wrapper.

### feat/encoders
Since we also need to encode `Content` and `Attachment` inside the related wrapper the functions have been refactored from the send method into the `encode` folder. Additionally the unique boundary calculation has also been refactored here and now uses `matchAll` instead of `replace`.