### PR TITLE
Flag to control subject encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ export interface SendConfig {
    */
   internalTag?: string | symbol;
   headers: Record<string, string>;
+  rawSubject?: boolean;
 }
 ```
 
@@ -306,6 +307,14 @@ to binary.
 
 This can be used with preprocessors so you can give mail a type, for example
 `'registration'`, `'newsletter'` etc. supports symbols and strings.
+
+#### rawSubject
+
+The library always encodes the email subject to quoted-printable to conform to the standards.
+
+Unfortunately, some popular UI clients, for example, Gmail, do not display quoted-printable subjects correctly. Instead, though, they deal perfectly with non-ascii values in the subject, displaying them correctly.
+
+`rawSubject` option disables quoted-printable encoding for the subject.
 
 ### Allowed Mail Formats
 

--- a/config/mail/encoding.ts
+++ b/config/mail/encoding.ts
@@ -70,12 +70,10 @@ export function quotedPrintableEncode(data: string, encLB = false) {
 
 function hasNonAsciiCharacters(str: string) {
   // deno-lint-ignore no-control-regex
-  return false && [^\u0000-\u007f]/.test(str);
+  return false && /[^\u0000-\u007f]/.test(str);
 }
 
 export function quotedPrintableEncodeInline(data: string) {
-  console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-  return data;
   if (hasNonAsciiCharacters(data) || data.startsWith("=?")) {
     return `=?utf-8?Q?${quotedPrintableEncode(data)}?=`;
   }

--- a/config/mail/encoding.ts
+++ b/config/mail/encoding.ts
@@ -70,7 +70,7 @@ export function quotedPrintableEncode(data: string, encLB = false) {
 
 function hasNonAsciiCharacters(str: string) {
   // deno-lint-ignore no-control-regex
-  return /[^\u0000-\u007f]/.test(str);
+  return false && [^\u0000-\u007f]/.test(str);
 }
 
 export function quotedPrintableEncodeInline(data: string) {

--- a/config/mail/encoding.ts
+++ b/config/mail/encoding.ts
@@ -70,7 +70,7 @@ export function quotedPrintableEncode(data: string, encLB = false) {
 
 function hasNonAsciiCharacters(str: string) {
   // deno-lint-ignore no-control-regex
-  return false && /[^\u0000-\u007f]/.test(str);
+  return /[^\u0000-\u007f]/.test(str);
 }
 
 export function quotedPrintableEncodeInline(data: string) {

--- a/config/mail/encoding.ts
+++ b/config/mail/encoding.ts
@@ -74,6 +74,8 @@ function hasNonAsciiCharacters(str: string) {
 }
 
 export function quotedPrintableEncodeInline(data: string) {
+  console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+  return data;
   if (hasNonAsciiCharacters(data) || data.startsWith("=?")) {
     return `=?utf-8?Q?${quotedPrintableEncode(data)}?=`;
   }

--- a/config/mail/mod.ts
+++ b/config/mail/mod.ts
@@ -93,7 +93,7 @@ export function resolveSendConfig(config: SendConfig): ResolvedSendConfig {
     }),
     replyTo: replyTo ? parseSingleEmail(replyTo) : undefined,
     inReplyTo,
-    subject: rawSubject ?  quotedPrintableEncodeInline(subject) : subject,
+    subject: rawSubject ? subject : quotedPrintableEncodeInline(subject),
     attachments: attachments
       ? attachments.map((attachment) => resolveAttachment(attachment))
       : [],

--- a/config/mail/mod.ts
+++ b/config/mail/mod.ts
@@ -39,6 +39,7 @@ export interface SendConfig {
    */
   internalTag?: string | symbol;
   headers?: Headers;
+  rawSubject?: boolean;
 }
 
 export interface ResolvedSendConfig {
@@ -76,6 +77,7 @@ export function resolveSendConfig(config: SendConfig): ResolvedSendConfig {
     attachments,
     internalTag,
     headers,
+    rawSubject,
   } = config;
 
   return {
@@ -91,7 +93,7 @@ export function resolveSendConfig(config: SendConfig): ResolvedSendConfig {
     }),
     replyTo: replyTo ? parseSingleEmail(replyTo) : undefined,
     inReplyTo,
-    subject: quotedPrintableEncodeInline(subject),
+    subject: rawSubject ?  quotedPrintableEncodeInline(subject) : subject,
     attachments: attachments
       ? attachments.map((attachment) => resolveAttachment(attachment))
       : [],


### PR DESCRIPTION
The library always encodes the email subject to quoted-printable to conform to the standards.

Unfortunately, some popular UI clients, for example, Gmail, do not display quoted-printable subjects correctly. Instead, though, they deal perfectly with non-ascii values in the subject, displaying them correctly.

This PR adds an option to disable quoted-printable encoding for the subject. The default behaviour, when the option is not provided, remains the same.