### PR TITLE
Remove type 'any' from MessageEvent

### DIFF
--- a/client/worker/worker-file.ts
+++ b/client/worker/worker-file.ts
@@ -6,6 +6,9 @@ import { SMTPClient } from "../basic/client.ts";
 import { ResolvedSendConfig } from "../../config/mail/mod.ts";
 import type { Message } from "./worker.ts";
 
+const doPostMessage = (message: Message): ReturnType<typeof postMessage> =>
+  postMessage(message);
+
 let client: SMTPClient;
 
 let cb: () => void;
@@ -21,13 +24,10 @@ async function send(config: ResolvedSendConfig) {
   if (!hasIdlePromise) {
     hasIdlePromise = true;
     await client.idle;
-    postMessage(false);
+    doPostMessage(false);
     hasIdlePromise = false;
   }
 }
-
-const doPostMessage = (message: Message): ReturnType<typeof postMessage> =>
-  postMessage(message);
 
 addEventListener("message", async (ev: MessageEvent) => {
   if (ev.data.__setup) {

--- a/client/worker/worker-file.ts
+++ b/client/worker/worker-file.ts
@@ -4,6 +4,7 @@
 
 import { SMTPClient } from "../basic/client.ts";
 import { ResolvedSendConfig } from "../../config/mail/mod.ts";
+import type { Message } from "./worker.ts";
 
 let client: SMTPClient;
 
@@ -25,6 +26,9 @@ async function send(config: ResolvedSendConfig) {
   }
 }
 
+const doPostMessage = (message: Message): ReturnType<typeof postMessage> =>
+  postMessage(message);
+
 addEventListener("message", async (ev: MessageEvent) => {
   if (ev.data.__setup) {
     client = new SMTPClient(ev.data.__setup);
@@ -32,7 +36,7 @@ addEventListener("message", async (ev: MessageEvent) => {
     return;
   }
   if (ev.data.__check_idle) {
-    postMessage(client.isSending);
+    doPostMessage(client.isSending);
     return;
   }
 
@@ -40,12 +44,12 @@ addEventListener("message", async (ev: MessageEvent) => {
     await readyPromise;
     try {
       const data = await send(ev.data.mail);
-      postMessage({
+      doPostMessage({
         __ret: ev.data.__mail,
         res: data,
       });
     } catch (ex) {
-      postMessage({
+      doPostMessage({
         __ret: ev.data.__mail,
         err: ex,
       });


### PR DESCRIPTION
To avoid the use of `deno-lint-ignore no-explicit-any` I got the type directly from `Promise`
Also exported the type so it can be reused in `postMessage`

I put the names that I though was good, but they can be changed.
