### PR TITLE
Fix: multiple To/Cc addresses, RFC 5322 compliant

### DIFF
--- a/client/basic/client.ts
+++ b/client/basic/client.ts
@@ -104,13 +104,13 @@ export class SMTPClient {
       if (config.to.length > 0) {
         this.#connection.writeCmd(
           "To: ",
-          config.to.map((m) => `${m.name} <${m.mail}>`).join(";"),
+          config.to.map((m) => `${m.name} <${m.mail}>`).join(","),
         );
       }
       if (config.cc.length > 0) {
         this.#connection.writeCmd(
           "Cc: ",
-          config.cc.map((m) => `${m.name} <${m.mail}>`).join(";"),
+          config.cc.map((m) => `${m.name} <${m.mail}>`).join(","),
         );
       }
 


### PR DESCRIPTION
According to RFC 5322, multiple e-mail addresses should by separated by comma instead of semicolon.

[3.4 RFC 5322 Address Specification](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4)

`   mailbox-list    =   (mailbox *("," mailbox)) / obs-mbox-list`

Using semicolon with e.g. Exim mail server leads to "550: header syntax error" message. 

With commas, sending to multiple addresses works as expected.